### PR TITLE
Fix issue with extra space after chat symbol.

### DIFF
--- a/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
+++ b/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
@@ -508,7 +508,7 @@ public class ChatListener implements Listener, EventExecutor {
             }
         }
 
-        return new Pair<>(currentChat, message);
+        return new Pair<>(currentChat, message.trim());
     }
 
     private String stylish(Player player, String message, String chat) {


### PR DESCRIPTION
How to replicate bug:
Type «! my message» instead of «!my message» for global chat with «!»
symbol and this will cause extra space bug.