### PR TITLE
Maven/Jar cleanup

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.Brikster</groupId>
-                <artifactId>BasePlugin</artifactId>
-                <version>${baseplugin.version}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>16.0.1</version>
-                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -42,8 +42,6 @@
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <manifestEntries>
                                 <Specification-Title>Chatty Bukkit-compatible chat plugin</Specification-Title>
-                                <Specification-Version>${project.version}</Specification-Version>
-                                <Specification-Vendor>MrBrikster</Specification-Vendor>
                                 <Implementation-Title>ru.mrbrikster.chatty</Implementation-Title>
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Implementation-Vendor>MrBrikster</Implementation-Vendor>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -117,7 +117,7 @@
             <groupId>com.nametagedit</groupId>
             <artifactId>nametagedit</artifactId>
             <version>4.1.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -41,7 +41,7 @@
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/**</exclude>
                             </excludes>
                         </filter>
                     </filters>
@@ -86,10 +86,13 @@
         <dependency>
             <groupId>com.github.Brikster</groupId>
             <artifactId>BasePlugin</artifactId>
+            <version>${baseplugin.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
@@ -107,7 +110,7 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -37,6 +37,19 @@
                             <shadedPattern>ru.mrbrikster.chatty.util.gson</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Specification-Title>Chatty Bukkit-compatible chat plugin</Specification-Title>
+                                <Specification-Version>${project.version}</Specification-Version>
+                                <Specification-Vendor>MrBrikster</Specification-Vendor>
+                                <Implementation-Title>ru.mrbrikster.chatty</Implementation-Title>
+                                <Implementation-Version>${project.version}</Implementation-Version>
+                                <Implementation-Vendor>MrBrikster</Implementation-Vendor>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
                     <filters>
                         <filter>
                             <artifact>*:*</artifact>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -37,6 +37,14 @@
                             <shadedPattern>ru.mrbrikster.chatty.util.gson</shadedPattern>
                         </relocation>
                     </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/maven/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixed annoying duplication warnings on compilation. Cleared META-INF folder, but created custom MANIFEST.MF just why not.
Fixed Chatty was containing a whole NameTagEdit plugin inside.

Also, why commons-io and jetbrains annotations are not shaded? Is it intended?