### PR TITLE
Update FormatMessage replace

### DIFF
--- a/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
+++ b/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
@@ -341,7 +341,7 @@ public class ChatListener implements Listener, EventExecutor {
 
         FormattedMessage formattedMessage = new FormattedMessage(format);
         formattedMessage.replace("{player}",
-                new JsonMessagePart(player.getDisplayName())
+                new JsonMessagePart(player.getName())
                         .command(stringVariablesFunction.apply(command))
                         .suggest(stringVariablesFunction.apply(suggestCommand))
                         .link(stringVariablesFunction.apply(link))


### PR DESCRIPTION
По хорошему надо использовать getName() вместо getDisplayName()
Ибо на многих серверах могкт использоваться кастомные имена, которые устанавливаются в setDisplayName()
И тогда Json форматирование отобразит при клике на чат не /msg <ник> как то необходимо, а /msg <диспплейный ник> из-за чего команда окажется неправильно введённой.