### PR TITLE
fix hex colors in pm message for recipient

### DIFF
--- a/spigot/src/main/java/ru/mrbrikster/chatty/commands/pm/PrivateMessageCommand.java
+++ b/spigot/src/main/java/ru/mrbrikster/chatty/commands/pm/PrivateMessageCommand.java
@@ -10,7 +10,7 @@ import ru.mrbrikster.baseplugin.config.Configuration;
 import ru.mrbrikster.chatty.Chatty;
 import ru.mrbrikster.chatty.chat.JsonStorage;
 import ru.mrbrikster.chatty.dependencies.PlayerTagManager;
-import ru.mrbrikster.chatty.json.fanciful.FancyMessage;
+import ru.mrbrikster.chatty.json.FormattedMessage;
 import ru.mrbrikster.chatty.moderation.AdvertisementModerationMethod;
 import ru.mrbrikster.chatty.moderation.ModerationManager;
 import ru.mrbrikster.chatty.moderation.SwearModerationMethod;
@@ -119,8 +119,8 @@ public abstract class PrivateMessageCommand extends BukkitCommand {
                 recipientFormat = TextUtil.stripHex(recipientFormat);
                 recipient.sendMessage(recipientFormat);
             } else {
-                new FancyMessage(recipientFormat)
-                        .send(recipient, sender instanceof Player ? ((Player) sender) : null);
+                FormattedMessage formattedMessage = new FormattedMessage(recipientFormat);
+                formattedMessage.toFancyMessage().send((Player) recipient, (Player) sender);
 
                 String soundName = configuration.getNode("pm.sound").getAsString(null);
                 if (soundName != null) {


### PR DESCRIPTION
Исправляет проблему с обработкой hex цветов в /pm для получателя сообщения. Внутренняя система скрытия сообщений от игрока в майнкрафт также работает, это изменение ничего не ломает.
![image](https://user-images.githubusercontent.com/62211966/174151501-c3cfea5f-e40a-4bda-941b-2f844bcc6550.png)
![image](https://user-images.githubusercontent.com/62211966/174151526-2cf9a8cd-38a5-40ed-9822-1f015223f59e.png)
