### PR TITLE
Make mention's sound based on chat range

### DIFF
--- a/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
+++ b/spigot/src/main/java/ru/mrbrikster/chatty/chat/ChatListener.java
@@ -485,16 +485,17 @@ public class ChatListener implements Listener, EventExecutor {
                                 .getAsString("&e&l@{player}").replace("{player}", playerName)))
                                 .tooltip(mentionTooltip).command(command).suggest(suggestCommand).link(link),
                         new LegacyMessagePart(TextUtil.getLastColors(event.getFormat())));
+                if (!configuration.getNode("json.mentions.range-based-sound").getAsBoolean(false) | event.getRecipients().contains(mentionedPlayer)){
+                    String soundName = configuration.getNode("json.mentions.sound").getAsString(null);
+                    if (soundName != null) {
+                        org.bukkit.Sound sound = Sound.byName(soundName);
+                        double soundVolume = (double) configuration.getNode("json.mentions.sound-volume").get(1d);
+                        double soundPitch = (double) configuration.getNode("json.mentions.sound-pitch").get(1d);
+                        mentionedPlayer.playSound(mentionedPlayer.getLocation(), sound, (float) soundVolume, (float) soundPitch);
+                    }
 
-                String soundName = configuration.getNode("json.mentions.sound").getAsString(null);
-                if (soundName != null) {
-                    org.bukkit.Sound sound = Sound.byName(soundName);
-                    double soundVolume = (double) configuration.getNode("json.mentions.sound-volume").get(1d);
-                    double soundPitch = (double) configuration.getNode("json.mentions.sound-pitch").get(1d);
-                    mentionedPlayer.playSound(mentionedPlayer.getLocation(), sound, (float) soundVolume, (float) soundPitch);
+                    event.getRecipients().add(mentionedPlayer);
                 }
-
-                event.getRecipients().add(mentionedPlayer);
             }
         }
 


### PR DESCRIPTION
At the moment, the mention's sound is played even when the chat is not visible to the person being mentioned.
This PR adds configurable option to set range based mention's sound.