### PR TITLE
Set join/quit message to null if player vanished

### DIFF
--- a/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
+++ b/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
@@ -36,7 +36,7 @@ public final class VanillaListener implements Listener {
         if (!joinConfig.isEnable()) {
             return;
         }
-        if (event.getPlayer().hasMetadata("vanished")) {
+        if (isVanished(event.getPlayer())) {
             event.setJoinMessage(null);
             return;
         }
@@ -81,7 +81,7 @@ public final class VanillaListener implements Listener {
         if (!quitConfig.isEnable()) {
             return;
         }
-        if (event.getPlayer().hasMetadata("vanished")) {
+        if (isVanished(event.getPlayer())) {
             event.setQuitMessage(null);
             return;
         }
@@ -116,7 +116,7 @@ public final class VanillaListener implements Listener {
         if (!deathConfig.isEnable()) {
             return;
         }
-        if (event.getEntity().hasMetadata("vanished")) {
+        if (isVanished(event.getEntity())) {
             event.setDeathMessage(null);
             return;
         }
@@ -155,6 +155,15 @@ public final class VanillaListener implements Listener {
         if (hasPermission && sound != null) {
             audiences.all().playSound(sound);
         }
+    }
+
+    private boolean isVanished(Player player) {
+        for (org.bukkit.metadata.MetadataValue meta : player.getMetadata("vanished")) {
+            if (meta.asBoolean()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Component formatWithPlaceholders(Component message, Player player) {

--- a/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
+++ b/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
@@ -37,6 +37,7 @@ public final class VanillaListener implements Listener {
             return;
         }
         if (event.getPlayer().hasMetadata("vanished")) {
+            event.setJoinMessage(null);
             return;
         }
 
@@ -81,6 +82,7 @@ public final class VanillaListener implements Listener {
             return;
         }
         if (event.getPlayer().hasMetadata("vanished")) {
+            event.setQuitMessage(null);
             return;
         }
 

--- a/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
+++ b/spigot/src/main/java/ru/brikster/chatty/misc/VanillaListener.java
@@ -117,6 +117,7 @@ public final class VanillaListener implements Listener {
             return;
         }
         if (event.getEntity().hasMetadata("vanished")) {
+            event.setDeathMessage(null);
             return;
         }
 


### PR DESCRIPTION
Pretty self-explanatory, I think.
<img width="344" height="32" alt="image" src="https://github.com/user-attachments/assets/c590fff2-c36c-4cb9-9ecb-d79cc463c388" />
