### PR TITLE
Fix `sendNobodyHeardYou` not sending when vanished players nearby

### DIFF
--- a/spigot/src/main/java/ru/brikster/chatty/chat/executor/AbstractChatEventExecutor.java
+++ b/spigot/src/main/java/ru/brikster/chatty/chat/executor/AbstractChatEventExecutor.java
@@ -347,20 +347,20 @@ public abstract class AbstractChatEventExecutor implements Listener {
 
     private void sendNobodyHeardYou(ChatEventFacade event, MessageContext<Component> middleContext) {
         if (middleContext.getChat().isSendNobodyHeardYou()) {
-            Set<Player> allowedRecipients = new HashSet<>();
-            allowedRecipients.add(event.getPlayer());
+            Set<Player> allowedRecipients = new HashSet<>(middleContext.getRecipients());
+
+            allowedRecipients.remove(event.getPlayer());
+
+            if (settings.isHideVanishedRecipients()) {
+                allowedRecipients.removeIf(player -> !event.getPlayer().canSee(player));
+            }
 
             if (middleContext.getChat().isEnableSpy()) {
-                allowedRecipients.addAll(MessageContextKeys
+                allowedRecipients.removeAll(MessageContextKeys
                         .getPlayers(middleContext, MessageContextKeys.SPY_RECIPIENTS));
             }
 
-            if (settings.isHideVanishedRecipients()) {
-                allowedRecipients.removeIf(player -> player != event.getPlayer()
-                        && !event.getPlayer().canSee(player));
-            }
-
-            if (allowedRecipients.containsAll(middleContext.getRecipients())) {
+            if (allowedRecipients.isEmpty()) {
                 ChattyMessages.send(audiences.player(event.getPlayer()),
                         messages.getNobodyHeard());
             }


### PR DESCRIPTION
## Fix `sendNobodyHeardYou` not sending when vanished players nearby

The `sendNobodyHeardYou()` method had a logic error that prevented the "Nobody heard you" notification from being sent to players when vanished players (_using PremiumVanish or similar_) were in the recipient list with `hideVanishedRecipients` enabled.

The original condition `allowedRecipients.containsAll(middleContext.getRecipients())` only works when there are no visible recipients. However, when vanished players are nearby:
- They remain in `middleContext.getRecipients()` 
- But they are not added to `allowedRecipients` (since they're invisible to the sender)
- This causes the condition to fail and the message is never sent

### Instead of checking if all recipients are allowed, we now:
1. Remove the sender from the recipient list
2. Remove vanished players (if `hideVanishedRecipients` is enabled)
3. Remove spy recipients
4. Send the message only if no recipients remain: `allowedRecipients.isEmpty()`